### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action.php
+++ b/action.php
@@ -29,7 +29,7 @@ class action_plugin_qna extends DokuWiki_Action_Plugin {
     /**
      * Register callbacks
      */
-    public function register($controller) {
+    public function register(Doku_Event_Handler $controller) {
         $controller->register_hook('PARSER_HANDLER_DONE', 'AFTER', $this, 'afterParserHandlerDone');
         $controller->register_hook('PARSER_CACHE_USE', 'BEFORE', $this, 'beforeParserCacheUse');
     }

--- a/syntax/block.php
+++ b/syntax/block.php
@@ -57,7 +57,7 @@ class syntax_plugin_qna_block extends DokuWiki_Syntax_Plugin {
     /**
      *
      */
-    public function handle($match, $state, $pos, $handler) {
+    public function handle($match, $state, $pos, Doku_Handler $handler) {
         if ($state == DOKU_LEXER_SPECIAL) {
             if ($match{1} == '?') {
                 $question = trim(substr($match, 4));
@@ -85,7 +85,7 @@ class syntax_plugin_qna_block extends DokuWiki_Syntax_Plugin {
     /**
      *
      */
-    public function render($mode, $renderer, $data) {
+    public function render($mode, Doku_Renderer $renderer, $data) {
         if ($mode == 'xhtml') {
             list($tag, $style) = explode('_', $data[0]);
 

--- a/syntax/header.php
+++ b/syntax/header.php
@@ -52,7 +52,7 @@ class syntax_plugin_qna_header extends DokuWiki_Syntax_Plugin {
     /**
      *
      */
-    function handle($match, $state, $pos, &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
         if ($state == DOKU_LEXER_SPECIAL) {
             $match = preg_replace('/^(\s*=)\?/', '$1=', $match);
 
@@ -70,7 +70,7 @@ class syntax_plugin_qna_header extends DokuWiki_Syntax_Plugin {
     /**
      *
      */
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         if ($mode == 'xhtml') {
             switch ($data[0]) {
                 case 'open':

--- a/syntax/toc.php
+++ b/syntax/toc.php
@@ -52,7 +52,7 @@ class syntax_plugin_qna_toc extends DokuWiki_Syntax_Plugin {
     /**
      *
      */
-    public function handle($match, $state, $pos, $handler) {
+    public function handle($match, $state, $pos, Doku_Handler $handler) {
         global $ID;
 
         if ($state == DOKU_LEXER_SPECIAL) {
@@ -74,7 +74,7 @@ class syntax_plugin_qna_toc extends DokuWiki_Syntax_Plugin {
     /**
      *
      */
-    public function render($mode, $renderer, $data) {
+    public function render($mode, Doku_Renderer $renderer, $data) {
         global $ID;
 
         if ($mode == 'xhtml') {


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.