### PR TITLE
Fixing compatibility issues with some templates

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,8 +1,8 @@
-div.dokuwiki div.qna-block {
+div.qna-block {
     margin-bottom: 1em;
 }
 
-div.dokuwiki div.qna-question {
+div.qna-question {
     padding: 0.5em 1em 0.3em 2em;
     background-color: __background_other__;
     background-image: url(images/question.png);
@@ -10,17 +10,17 @@ div.dokuwiki div.qna-question {
     background-position: top left;
 }
 
-div.dokuwiki div.qna-title {
+div.qna-title {
     font-size: 130%;
     font-weight: bold;
     margin-bottom: 0.5em;
 }
 
-div.dokuwiki div.qna-title a {
+div.qna-title a {
     text-decoration: none;
 }
 
-div.dokuwiki div.qna-answer {
+div.qna-answer {
     border-top: 1px dashed __border__;
     padding: 1em 1em 0.1em 2em;
     background-color: __background_other__;


### PR DESCRIPTION
Some templates — like [Dokui](https://www.dokuwiki.org/template:dokui) — don't use the `dokuwiki` CSS class.
This pull request removes the references to this class to make QNA works with any template.